### PR TITLE
Allow to namespace the database tables.

### DIFF
--- a/cmd/migrate_cmd.go
+++ b/cmd/migrate_cmd.go
@@ -21,11 +21,7 @@ func migrate(config *conf.Configuration) {
 		logrus.Fatalf("Error opening database: %+v", err)
 	}
 
-	db.AutoMigrate(models.Address{})
-	db.AutoMigrate(models.LineItem{})
-	db.AutoMigrate(models.Order{})
-	db.AutoMigrate(models.OrderNote{})
-	db.AutoMigrate(models.SiteSettings{})
-	db.AutoMigrate(models.Transaction{})
-	db.AutoMigrate(models.User{})
+	if err := models.AutoMigrate(db); err != nil {
+		logrus.Fatalf("Error migrating tables: %+v", err)
+	}
 }

--- a/cmd/root_cmd.go
+++ b/cmd/root_cmd.go
@@ -5,6 +5,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/netlify/netlify-commerce/conf"
+	"github.com/netlify/netlify-commerce/models"
 )
 
 // rootCmd will run the log streamer
@@ -32,6 +33,10 @@ func execWithConfig(cmd *cobra.Command, fn func(config *conf.Configuration)) {
 	config, err := conf.Load(configFile)
 	if err != nil {
 		logrus.Fatalf("Failed to load configration: %+v", err)
+	}
+
+	if config.DB.Namespace != "" {
+		models.Namespace = config.DB.Namespace
 	}
 
 	fn(config)

--- a/conf/configuration.go
+++ b/conf/configuration.go
@@ -19,8 +19,10 @@ type Configuration struct {
 	} `mapstructure:"jwt" json:"jwt"`
 
 	DB struct {
-		Driver  string `mapstructure:"driver" json:"driver"`
-		ConnURL string `mapstructure:"url" json:"url"`
+		Driver      string `mapstructure:"driver" json:"driver"`
+		ConnURL     string `mapstructure:"url" json:"url"`
+		Namespace   string `mapstructure:"namespace" json:"namespace"`
+		Automigrate bool   `mapstructure:"automigrate" json:"automigrate"`
 	}
 
 	API struct {
@@ -86,6 +88,9 @@ func handleNested(config *Configuration) (*Configuration, error) {
 
 	config.DB.Driver = viper.GetString("db.driver")
 	config.DB.ConnURL = viper.GetString("db.url")
+	config.DB.Namespace = viper.GetString("db.namespace")
+	config.DB.Automigrate = viper.GetBool("db.automigrate")
+
 	if config.DB.ConnURL == "" && os.Getenv("DATABASE_URL") != "" {
 		config.DB.ConnURL = os.Getenv("DATABASE_URL")
 	}

--- a/models/address.go
+++ b/models/address.go
@@ -23,6 +23,10 @@ type Address struct {
 	DeletedAt *time.Time `json:"deleted_at"`
 }
 
+func (Address) TableName() string {
+	return tableName("addresses")
+}
+
 func (a *Address) Valid() bool {
 	if a.LastName == "" {
 		return false

--- a/models/connection.go
+++ b/models/connection.go
@@ -6,9 +6,16 @@ import (
 	_ "github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"
 	"github.com/netlify/netlify-commerce/conf"
+	"github.com/pkg/errors"
 
 	"github.com/jinzhu/gorm"
 )
+
+// Namespace puts all tables names under a common
+// namespace. This is useful if you want to use
+// the same database for several services and don't
+// want table names to collide.
+var Namespace string
 
 // Configuration defines the info necessary to connect to a storage engine
 type Configuration struct {
@@ -20,15 +27,38 @@ type Configuration struct {
 func Connect(config *conf.Configuration) (*gorm.DB, error) {
 	db, err := gorm.Open(config.DB.Driver, config.DB.ConnURL)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "opening database connection")
 	}
 
 	err = db.DB().Ping()
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrap(err, "checking database connection")
 	}
 
-	db.AutoMigrate(&Order{}, &Address{}, &LineItem{}, &OrderNote{}, &User{}, &Transaction{})
+	if config.DB.Automigrate {
+		if err := AutoMigrate(db); err != nil {
+			return nil, errors.Wrap(err, "migrating tables")
+		}
+	}
 
 	return db, nil
+}
+
+func tableName(defaultName string) string {
+	if Namespace != "" {
+		return Namespace + "_" + defaultName
+	}
+	return defaultName
+}
+
+func AutoMigrate(db *gorm.DB) error {
+	db = db.AutoMigrate(Address{},
+		LineItem{},
+		Order{},
+		OrderData{},
+		OrderNote{},
+		SiteSettings{},
+		Transaction{},
+		User{})
+	return db.Error
 }

--- a/models/line_item.go
+++ b/models/line_item.go
@@ -24,6 +24,10 @@ type LineItem struct {
 	DeletedAt *time.Time `json:"-"`
 }
 
+func (LineItem) TableName() string {
+	return tableName("line_items")
+}
+
 type PriceMetadata struct {
 	Amount   string `json:"amount"`
 	Currency string `json:"currency"`

--- a/models/order_notes.go
+++ b/models/order_notes.go
@@ -13,3 +13,7 @@ type OrderNote struct {
 	UpdatedAt time.Time  `json:"updated_at"`
 	DeletedAt *time.Time `json:"-"`
 }
+
+func (OrderNote) TableName() string {
+	return tableName("orders_notes")
+}

--- a/models/site_settings.go
+++ b/models/site_settings.go
@@ -4,6 +4,10 @@ type SiteSettings struct {
 	Taxes []*Tax `json:"taxes"`
 }
 
+func (SiteSettings) TableName() string {
+	return tableName("sites_settings")
+}
+
 type Tax struct {
 	Percentage   uint64   `json:"percentage"`
 	ProductTypes []string `json:"product_types"`

--- a/models/transaction.go
+++ b/models/transaction.go
@@ -31,6 +31,10 @@ type Transaction struct {
 	DeletedAt *time.Time `json:"-"`
 }
 
+func (Transaction) TableName() string {
+	return tableName("transactions")
+}
+
 // NewTransaction returns a new transaction for an order
 func NewTransaction(order *Order) *Transaction {
 	return &Transaction{

--- a/models/user.go
+++ b/models/user.go
@@ -10,3 +10,7 @@ type User struct {
 	UpdatedAt time.Time
 	DeletedAt *time.Time
 }
+
+func (User) TableName() string {
+	return tableName("users")
+}


### PR DESCRIPTION
This is useful if you want to have two services in the same database
and don't want table names to collide.

- Auto migrate tables on demand.

Signed-off-by: David Calavera <david.calavera@gmail.com>