### PR TITLE
Handle tax calculations for pricing bundles

### DIFF
--- a/api/order.go
+++ b/api/order.go
@@ -598,9 +598,7 @@ func (a *API) createLineItems(ctx context.Context, tx *gorm.DB, order *models.Or
 		return &HTTPError{Code: 500, Message: err.Error()}
 	}
 
-	if err := order.CalculateTotal(settings); err != nil {
-		return &HTTPError{Code: 500, Message: err.Error()}
-	}
+	order.CalculateTotal(settings)
 
 	return nil
 }

--- a/api/order.go
+++ b/api/order.go
@@ -18,7 +18,7 @@ import (
 )
 
 type OrderLineItem struct {
-	SKU      string `json:sku`
+	SKU      string `json:"sku"`
 	Path     string `json:"path"`
 	Quantity uint64 `json:"quantity"`
 }

--- a/api/order_test.go
+++ b/api/order_test.go
@@ -30,7 +30,7 @@ func TestOrderCreationWithSimpleOrder(t *testing.T) {
 				<html>
 				<head><title>Test Product</title></head>
 				<body>
-					<script id="netlify-commerce-product">
+					<script class="netlify-commerce-product">
 					{"sku": "product-1", "title": "Product 1", "prices": [
 						{"amount": "9.99", "currency": "USD"}
 					]}

--- a/api/order_test.go
+++ b/api/order_test.go
@@ -67,8 +67,6 @@ func TestOrderCreationWithSimpleOrder(t *testing.T) {
 	order := &models.Order{}
 	extractPayload(t, 201, recorder, order)
 
-	fmt.Printf("Order: %v\n", order.ShippingAddress)
-
 	var total uint64
 	total = 999
 	assert.Equal(t, "info@example.com", order.Email, "Total should be info@example.com, was %v", order.Email)
@@ -146,9 +144,9 @@ func TestOrderCreationForBundleWithTaxes(t *testing.T) {
 				<body>
 					<script class="netlify-commerce-product">
 					{"sku": "product-1", "title": "Product 1", "type": "Book", "prices": [
-						{"amount": "9.99", "currency": "USD", items: [
+						{"amount": "9.99", "currency": "USD", "items": [
 							{"amount": "7.00", "type": "Book"},
-							{"amount": "2.99", "type": "E-Book"},
+							{"amount": "2.99", "type": "E-Book"}
 						]}
 					]}
 					</script>

--- a/api/payments.go
+++ b/api/payments.go
@@ -435,7 +435,6 @@ func (p *paypalProvider) charge(amount uint64, currency, paymentID, payerID stri
 		return "", fmt.Errorf("The paypal payment must have exactly 1 transaction, had %v", len(payment.Transactions))
 	}
 
-	fmt.Printf("Transactions: %v", payment.Transactions[0])
 	if payment.Transactions[0].Amount == nil {
 		return "", fmt.Errorf("No amount in this transaction %v", payment.Transactions[0])
 	}

--- a/api/payments.go
+++ b/api/payments.go
@@ -340,23 +340,6 @@ func requireAdmin(ctx context.Context, paramKey string) (*logrus.Entry, string, 
 }
 
 func (a *API) verifyAmount(ctx context.Context, order *models.Order, amount uint64) error {
-	config := getConfig(ctx)
-
-	settings := &models.SiteSettings{}
-	resp, err := a.httpClient.Get(config.SiteURL + "/netlify-commerce/settings.json")
-	if err != nil {
-		return err
-	}
-	defer resp.Body.Close()
-	if resp.StatusCode == 200 {
-		decoder := json.NewDecoder(resp.Body)
-		if err := decoder.Decode(settings); err != nil {
-			return err
-		}
-	}
-
-	order.CalculateTotal(settings)
-
 	if order.Total != amount {
 		return fmt.Errorf("Amount calculated for order didn't match amount to charge. %v vs %v", order.Total, amount)
 	}

--- a/api/paypal.go
+++ b/api/paypal.go
@@ -19,7 +19,6 @@ var paypalExperience Experience
 
 // PaypalCreatePayment creates a new payment that can be authorized in the browser
 func (a *API) PaypalCreatePayment(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-	fmt.Printf("Hello from paypal method... %v", a.paypal)
 	profile, err := a.getExperience()
 	if err != nil {
 		internalServerError(w, fmt.Sprintf("Error creating paypal experience: %v", err))

--- a/api/utils_test.go
+++ b/api/utils_test.go
@@ -255,6 +255,6 @@ func extractPayload(t *testing.T, code int, recorder *httptest.ResponseRecorder,
 			assert.FailNow(t, "Failed to extract body")
 		}
 	} else {
-		assert.FailNow(t, "Unexpected code: ", code)
+		assert.FailNow(t, fmt.Sprintf("Unexpected code: %v - expected: %v", recorder.Code, code))
 	}
 }

--- a/models/order.go
+++ b/models/order.go
@@ -180,7 +180,7 @@ func (o *Order) UpdateOrderData(tx *gorm.DB, updates *map[string]interface{}) er
 	return nil
 }
 
-func (o *Order) CalculateTotal(settings *SiteSettings) error {
+func (o *Order) CalculateTotal(settings *SiteSettings) {
 	// Calculate taxes/shipping here
 	var taxes uint64
 	if o.VATNumber == "" {
@@ -191,7 +191,6 @@ func (o *Order) CalculateTotal(settings *SiteSettings) error {
 
 	o.Taxes = taxes
 	o.Total = o.SubTotal + taxes
-	return nil
 }
 
 func inList(list []string, candidate string) bool {


### PR DESCRIPTION
In some cases a line item consists of different products bundled together. Legally we need to calculate the VAT based on the different types of product and their individual parts of the price.

This PR changes the time of the pricing calculation to when the order is created, and handles VAT for bundles.